### PR TITLE
feat: editar nombre y emoji de una lista

### DIFF
--- a/src/components/CreateListModal.tsx
+++ b/src/components/CreateListModal.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { createClient } from "@/lib/supabase/client";
 import { X } from "lucide-react";
+import type { List } from "@/lib/supabase/types";
 
 const EMOJI_OPTIONS = [
   "🎬",
@@ -23,11 +24,13 @@ interface Props {
   userId: string;
   onClose: () => void;
   onCreated: () => void;
+  editList?: List;
+  onUpdated?: (list: List) => void;
 }
 
-export default function CreateListModal({ userId, onClose, onCreated }: Props) {
-  const [name, setName] = useState("");
-  const [emoji, setEmoji] = useState("🎬");
+export default function CreateListModal({ userId, onClose, onCreated, editList, onUpdated }: Props) {
+  const [name, setName] = useState(editList?.name ?? "");
+  const [emoji, setEmoji] = useState(editList?.emoji ?? "🎬");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -35,26 +38,39 @@ export default function CreateListModal({ userId, onClose, onCreated }: Props) {
 
   async function handleCreate(e: React.FormEvent) {
     e.preventDefault();
-    console.log("handleCreate called, name:", name, "userId:", userId);
     if (!name.trim()) return;
 
     setLoading(true);
     setError(null);
 
-    const { data, error } = await supabase.from("lists").insert({
-      name: name.trim(),
-      emoji,
-      owner_id: userId,
-    }).select();
+    if (editList) {
+      const { data, error } = await supabase
+        .from("lists")
+        .update({ name: name.trim(), emoji })
+        .eq("id", editList.id)
+        .select()
+        .single();
 
-    console.log("Insert result:", { data, error });
-
-    if (error) {
-      console.error("Create list error:", error);
-      setError(error.message);
-      setLoading(false);
+      if (error) {
+        setError(error.message);
+        setLoading(false);
+      } else {
+        onUpdated?.(data);
+        onClose();
+      }
     } else {
-      onCreated();
+      const { data, error } = await supabase.from("lists").insert({
+        name: name.trim(),
+        emoji,
+        owner_id: userId,
+      }).select();
+
+      if (error) {
+        setError(error.message);
+        setLoading(false);
+      } else {
+        onCreated();
+      }
     }
   }
 
@@ -69,7 +85,7 @@ export default function CreateListModal({ userId, onClose, onCreated }: Props) {
         <div className="w-10 h-1 bg-border rounded-full mx-auto mb-6" />
 
         <div className="flex items-center justify-between mb-6">
-          <h2 className="text-lg font-semibold text-text">Nueva lista</h2>
+          <h2 className="text-lg font-semibold text-text">{editList ? "Editar lista" : "Nueva lista"}</h2>
           <button
             onClick={onClose}
             className="w-8 h-8 rounded-full bg-surface border border-border flex items-center justify-center text-muted hover:text-text"
@@ -141,7 +157,7 @@ export default function CreateListModal({ userId, onClose, onCreated }: Props) {
               className="flex-1 py-3 rounded-xl text-bg text-sm font-semibold transition-opacity disabled:opacity-50"
               style={{ backgroundColor: "#c8a96e" }}
             >
-              {loading ? "Creando..." : "Crear lista"}
+              {loading ? (editList ? "Guardando..." : "Creando...") : editList ? "Guardar" : "Crear lista"}
             </button>
           </div>
         </form>

--- a/src/components/ListDetailClient.tsx
+++ b/src/components/ListDetailClient.tsx
@@ -2,12 +2,13 @@
 
 import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
-import { ArrowLeft, Plus, Trash2, UserPlus } from "lucide-react";
+import { ArrowLeft, Plus, Trash2, UserPlus, Pencil } from "lucide-react";
 import { createClient } from "@/lib/supabase/client";
 import type { Item, List } from "@/lib/supabase/types";
 import RankItem from "./RankItem";
 import AddItemModal from "./AddItemModal";
 import ShareModal, { type MemberWithProfile } from "./ShareModal";
+import CreateListModal from "./CreateListModal";
 
 function localToday() {
   const d = new Date();
@@ -36,7 +37,10 @@ export default function ListDetailClient({
   const [votedItemId, setVotedItemId] = useState<string | null>(
     latestVote?.voted_date === localToday() ? latestVote.item_id : null
   );
+  const [listName, setListName] = useState(list.name);
+  const [listEmoji, setListEmoji] = useState(list.emoji);
   const [showAddModal, setShowAddModal] = useState(false);
+  const [showEditListModal, setShowEditListModal] = useState(false);
   const [editingItem, setEditingItem] = useState<Item | null>(null);
   const [showShareModal, setShowShareModal] = useState(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
@@ -227,13 +231,20 @@ export default function ListDetailClient({
         </button>
 
         <div className="flex items-center gap-2">
-          <span className="text-2xl">{list.emoji}</span>
-          <h1 className="text-lg font-semibold text-text">{list.name}</h1>
+          <span className="text-2xl">{listEmoji}</span>
+          <h1 className="text-lg font-semibold text-text">{listName}</h1>
         </div>
 
         <div className="flex items-center gap-2">
           {isOwner && (
             <>
+              <button
+                onClick={() => setShowEditListModal(true)}
+                className="w-10 h-10 rounded-full flex items-center justify-center transition-colors text-muted hover:text-text hover:bg-surface"
+                aria-label="Editar lista"
+              >
+                <Pencil size={16} />
+              </button>
               <button
                 onClick={() => setShowShareModal(true)}
                 className="w-10 h-10 rounded-full flex items-center justify-center transition-colors text-muted hover:text-text hover:bg-surface"
@@ -427,6 +438,21 @@ export default function ListDetailClient({
         </>
       )}
 
+      {/* Edit list modal */}
+      {showEditListModal && (
+        <CreateListModal
+          userId={userId}
+          editList={{ ...list, name: listName, emoji: listEmoji }}
+          onClose={() => setShowEditListModal(false)}
+          onCreated={() => {}}
+          onUpdated={(updated) => {
+            setListName(updated.name);
+            setListEmoji(updated.emoji);
+            setShowEditListModal(false);
+          }}
+        />
+      )}
+
       {/* Add item modal */}
       {showAddModal && (
         <AddItemModal
@@ -480,13 +506,13 @@ export default function ListDetailClient({
             <div className="w-10 h-1 bg-border rounded-full mx-auto mb-6" />
 
             <div className="text-center mb-6">
-              <p className="text-3xl mb-3">{list.emoji}</p>
+              <p className="text-3xl mb-3">{listEmoji}</p>
               <h2 className="text-lg font-semibold text-text mb-1">
                 Eliminar lista
               </h2>
               <p className="text-muted text-sm">
                 ¿Seguro que quieres eliminar{" "}
-                <span className="text-text font-medium">{list.name}</span>? Esta
+                <span className="text-text font-medium">{listName}</span>? Esta
                 acción no se puede deshacer.
               </p>
             </div>


### PR DESCRIPTION
## Summary

- Nuevo botón de lápiz en el header de la lista (solo visible para el owner)
- Abre el modal de creación reutilizado en modo edición, con nombre y emoji pre-rellenados
- Al guardar, actualiza el header de la vista en tiempo real sin recargar

## Test plan

- [ ] Pulsar el lápiz abre el modal con los datos actuales de la lista
- [ ] Cambiar nombre y/o emoji y guardar actualiza el header inmediatamente
- [ ] El botón no aparece si no eres el owner de la lista

🤖 Generated with [Claude Code](https://claude.com/claude-code)