### PR TITLE
feat: mostrar resultado seleccionado al abrir edición de ítem

### DIFF
--- a/src/components/AddItemModal.tsx
+++ b/src/components/AddItemModal.tsx
@@ -37,7 +37,22 @@ export default function AddItemModal({
   const [results, setResults] = useState<ExternalResult[]>([]);
   const [searching, setSearching] = useState(false);
   const [showDropdown, setShowDropdown] = useState(false);
-  const [selectedResult, setSelectedResult] = useState<ExternalResult | null>(null);
+
+  const initialSelected: ExternalResult | null = (() => {
+    if (!editItem || !editItem.external_id) return null;
+    const data = editItem.external_data as Record<string, unknown> | null;
+    return {
+      external_id: editItem.external_id as string,
+      title: editItem.title,
+      poster_path: (data?.poster_path as string | undefined) ?? null,
+      genre: (data?.genre as string | undefined) ?? null,
+      year: (data?.year as string | undefined) ?? null,
+      overview: (data?.overview as string | undefined) ?? null,
+      type: null,
+    };
+  })();
+
+  const [selectedResult, setSelectedResult] = useState<ExternalResult | null>(initialSelected);
   const [externalId, setExternalId] = useState<string | null>(
     (editItem?.external_id as string | null) ?? null
   );


### PR DESCRIPTION
## Summary
- Al editar un ítem que proviene de TMDB, el modal abre directamente con la vista de resultado seleccionado (póster + título + género/año) en lugar del input de texto vacío
- El usuario puede pulsar X para limpiar la selección y buscar otra cosa
- Los ítems sin datos externos (añadidos manualmente) siguen abriendo con el input normal

## Test plan
- [ ] Editar un ítem añadido desde TMDB — verificar que abre con la tarjeta del resultado, no con el input
- [ ] Pulsar X en la tarjeta — verificar que aparece el buscador para elegir otro resultado
- [ ] Guardar sin cambios — verificar que los datos se mantienen correctamente
- [ ] Editar un ítem manual (sin external_id) — verificar que sigue abriendo con el input

🤖 Generated with [Claude Code](https://claude.com/claude-code)