### PR TITLE
feat: music albums service with MusicBrainz

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -25,6 +25,10 @@ const nextConfig: NextConfig = {
       },
       {
         protocol: "https",
+        hostname: "coverartarchive.org",
+      },
+      {
+        protocol: "https",
         hostname: "vtkadxzditmkkfcnleoh.supabase.co",
         pathname: "/storage/v1/object/public/**",
       },

--- a/src/app/api/search/[service]/route.ts
+++ b/src/app/api/search/[service]/route.ts
@@ -38,6 +38,9 @@ export async function GET(
   const cookieLocale = req.cookies.get("NEXT_LOCALE")?.value;
   const locale = cookieLocale === "en" ? "en" : cookieLocale === "fr" ? "fr" : cookieLocale === "it" ? "it" : "es";
 
+  if (service === "books") return searchBooks(q.trim(), locale);
+  if (service === "albums") return searchAlbums(q.trim());
+
   const apiKey = process.env.TMDB_API_KEY;
   if (!apiKey) {
     return NextResponse.json({ error: "TMDB_API_KEY not configured" }, { status: 500 });
@@ -45,7 +48,6 @@ export async function GET(
 
   if (service === "movies") return searchMovies(q.trim(), apiKey, locale);
   if (service === "tv") return searchTV(q.trim(), apiKey, locale);
-  if (service === "books") return searchBooks(q.trim(), locale);
   if (service === "games") return searchGames(q.trim(), process.env.RAWG_API_KEY ?? "");
 
   return NextResponse.json({ error: "Unknown service" }, { status: 400 });
@@ -142,6 +144,42 @@ async function searchGames(query: string, apiKey: string): Promise<NextResponse>
         year: ((r.released as string)?.slice(0, 4) ?? null),
         genre: genres.length > 0 ? genres[0].name : null,
         poster_path: (r.background_image as string | null) ?? null,
+        overview: null,
+      };
+    });
+
+  return NextResponse.json(results);
+}
+
+async function searchAlbums(query: string): Promise<NextResponse> {
+  const url = `https://musicbrainz.org/ws/2/release/?query=${encodeURIComponent(query)}&fmt=json&limit=7`;
+
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      next: { revalidate: 60 },
+      headers: { "User-Agent": "rankit/1.0 (https://github.com/javierugarte/rankit)" },
+    });
+  } catch {
+    return NextResponse.json({ error: "Network error" }, { status: 502 });
+  }
+
+  if (!res.ok) return NextResponse.json({ error: "MusicBrainz error" }, { status: 502 });
+
+  const data = await res.json();
+
+  const results: ExternalResult[] = (data.releases ?? [])
+    .slice(0, 7)
+    .map((r: Record<string, unknown>) => {
+      const artistCredits = (r["artist-credit"] as { name?: string; artist?: { name: string } }[] | undefined) ?? [];
+      const artist = artistCredits[0]?.name ?? artistCredits[0]?.artist?.name ?? null;
+      const mbid = r.id as string;
+      return {
+        external_id: mbid,
+        title: (r.title ?? "") as string,
+        year: ((r.date as string)?.slice(0, 4) ?? null),
+        genre: artist,
+        poster_path: mbid ? `https://coverartarchive.org/release/${mbid}/front` : null,
         overview: null,
       };
     });

--- a/src/lib/services/index.ts
+++ b/src/lib/services/index.ts
@@ -1,4 +1,4 @@
-export type ServiceId = "movies" | "tv" | "books" | "games";
+export type ServiceId = "movies" | "tv" | "books" | "games" | "albums";
 
 export interface ExternalResult {
   external_id: string;
@@ -56,6 +56,15 @@ export const SERVICES: Record<ServiceId, ServiceConfig> = {
     posterBase: "",
     posterAspect: "landscape",
   },
+  albums: {
+    id: "albums",
+    label: "Álbumes",
+    apiLabel: "MusicBrainz",
+    searchEndpoint: "/api/search/albums",
+    placeholder: "Buscar álbum...",
+    posterBase: "",
+    posterAspect: "portrait",
+  },
 };
 
 export function getService(listType: string | null | undefined): ServiceConfig | null {
@@ -69,6 +78,7 @@ export const LIST_TYPE_OPTIONS: { value: string | null; label: string; emoji: st
   { value: "tv", label: "Series", emoji: "📺" },
   { value: "books", label: "Libros", emoji: "📚" },
   { value: "games", label: "Videojuegos", emoji: "🎮" },
+  { value: "albums", label: "Álbumes", emoji: "🎵" },
 ];
 
 export const TMDB_POSTER_BASE = "https://image.tmdb.org/t/p/w185";


### PR DESCRIPTION
## Summary
- Adds `albums` as a new `ServiceId` and list type backed by the MusicBrainz search API (no API key required)
- Implements `searchAlbums` handler in `/api/search/[service]`, mapping releases to `ExternalResult[]` with artist as genre field
- Fetches cover art URLs from Cover Art Archive (`coverartarchive.org`) and adds its domain to `next.config.ts` image patterns
- Adds `albums` option to `LIST_TYPE_OPTIONS` so it appears in `CreateListModal`

Closes #19

## Test plan
- [ ] Create a list with type "Álbumes"
- [ ] Add an item — autocomplete should search MusicBrainz and show album titles, artists, and release years
- [ ] Cover art images from coverartarchive.org should load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)