### PR TITLE
[codex] Add list vote history

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -43,6 +43,7 @@
     "votedBanner": "✓ Already voted today · Come back in {time}",
     "editList": "Edit list",
     "shareList": "Share list",
+    "voteHistory": "Vote history",
     "leaveList": "Leave list",
     "markDone": "Mark as done",
     "markDoneWatched": "Mark as watched",
@@ -224,5 +225,13 @@
     "vote": "vote",
     "votes": "votes",
     "you": "You"
+  },
+  "voteHistory": {
+    "title": "Vote history",
+    "close": "Close",
+    "empty": "No votes have been cast on this list yet.",
+    "votedFor": "voted for",
+    "unknownUser": "Someone",
+    "unknownItem": "a deleted item"
   }
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -43,6 +43,7 @@
     "votedBanner": "✓ Ya votaste hoy · Regresa en {time}",
     "editList": "Editar lista",
     "shareList": "Compartir lista",
+    "voteHistory": "Historial de votos",
     "leaveList": "Salir de la lista",
     "markDone": "Marcar como hecho",
     "markDoneWatched": "Marcar como visto",
@@ -224,5 +225,13 @@
     "vote": "voto",
     "votes": "votos",
     "you": "Tú"
+  },
+  "voteHistory": {
+    "title": "Historial de votos",
+    "close": "Cerrar",
+    "empty": "Todavía no se ha votado en esta lista.",
+    "votedFor": "votó a",
+    "unknownUser": "Alguien",
+    "unknownItem": "un ítem eliminado"
   }
 }

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -43,6 +43,7 @@
     "votedBanner": "✓ Déjà voté aujourd'hui · Revenez dans {time}",
     "editList": "Modifier la liste",
     "shareList": "Partager la liste",
+    "voteHistory": "Historique des votes",
     "leaveList": "Quitter la liste",
     "markDone": "Marquer comme fait",
     "markDoneWatched": "Marquer comme vu",
@@ -224,5 +225,13 @@
     "vote": "vote",
     "votes": "votes",
     "you": "Vous"
+  },
+  "voteHistory": {
+    "title": "Historique des votes",
+    "close": "Fermer",
+    "empty": "Aucun vote n’a encore été exprimé dans cette liste.",
+    "votedFor": "a voté pour",
+    "unknownUser": "Quelqu’un",
+    "unknownItem": "un élément supprimé"
   }
 }

--- a/messages/it.json
+++ b/messages/it.json
@@ -43,6 +43,7 @@
     "votedBanner": "✓ Hai già votato oggi · Torna tra {time}",
     "editList": "Modifica lista",
     "shareList": "Condividi lista",
+    "voteHistory": "Cronologia voti",
     "leaveList": "Abbandona la lista",
     "markDone": "Segna come fatto",
     "markDoneWatched": "Segna come visto",
@@ -224,5 +225,13 @@
     "vote": "voto",
     "votes": "voti",
     "you": "Tu"
+  },
+  "voteHistory": {
+    "title": "Cronologia voti",
+    "close": "Chiudi",
+    "empty": "Non ci sono ancora voti in questa lista.",
+    "votedFor": "ha votato per",
+    "unknownUser": "Qualcuno",
+    "unknownItem": "un elemento eliminato"
   }
 }

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -43,6 +43,7 @@
     "votedBanner": "✓ Você já votou hoje · Volte em {time}",
     "editList": "Editar lista",
     "shareList": "Compartilhar lista",
+    "voteHistory": "Histórico de votos",
     "leaveList": "Sair da lista",
     "markDone": "Marcar como feito",
     "markDoneWatched": "Marcar como assistido",
@@ -224,5 +225,13 @@
     "vote": "voto",
     "votes": "votos",
     "you": "Você"
+  },
+  "voteHistory": {
+    "title": "Histórico de votos",
+    "close": "Fechar",
+    "empty": "Ainda não há votos nesta lista.",
+    "votedFor": "votou em",
+    "unknownUser": "Alguém",
+    "unknownItem": "um item excluído"
   }
 }

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -83,8 +83,8 @@ export default async function AppLayout({ children }: { children: React.ReactNod
       ? supabase.from("items").select("*", { count: "exact", head: true }).eq("completed", true).in("list_id", ownedListIds)
       : Promise.resolve({ count: 0 }),
     listIds.length > 0
-      ? supabase.from("votes").select("item_id, user_id").in("list_id", listIds)
-      : Promise.resolve({ data: [] as { item_id: string; user_id: string }[] }),
+      ? supabase.from("votes").select("item_id, user_id, voted_date").in("list_id", listIds)
+      : Promise.resolve({ data: [] as { item_id: string; user_id: string; voted_date: string }[] }),
   ]);
 
   // ── Build home data ─────────────────────────────────────────────────────────
@@ -120,11 +120,15 @@ export default async function AppLayout({ children }: { children: React.ReactNod
     }
   }
 
-  // Build votesByItem: item_id → user_id → count
-  const votesByItem: Record<string, Record<string, number>> = {};
-  for (const vote of (allVotesResult.data ?? []) as { item_id: string; user_id: string }[]) {
-    if (!votesByItem[vote.item_id]) votesByItem[vote.item_id] = {};
-    votesByItem[vote.item_id][vote.user_id] = (votesByItem[vote.item_id][vote.user_id] ?? 0) + 1;
+  const votesByList: Record<string, { item_id: string; user_id: string; voted_date: string }[]> = {};
+  const itemListIdMap = new Map(
+    (allItemsResult.data ?? []).map((item) => [item.id, item.list_id])
+  );
+  for (const vote of (allVotesResult.data ?? []) as { item_id: string; user_id: string; voted_date: string }[]) {
+    const voteListId = itemListIdMap.get(vote.item_id);
+    if (!voteListId) continue;
+    if (!votesByList[voteListId]) votesByList[voteListId] = [];
+    votesByList[voteListId].push(vote);
   }
 
   // Build allParticipantsByList: list_id → all participants (owner + members)
@@ -177,10 +181,6 @@ export default async function AppLayout({ children }: { children: React.ReactNod
   const listDetails = allLists.map((list) => {
     const isOwner = list.owner_id === user.id;
     const items = itemsByList[list.id] ?? [];
-    const initialVotesByItem: Record<string, Record<string, number>> = {};
-    for (const item of items) {
-      initialVotesByItem[item.id] = votesByItem[item.id] ?? {};
-    }
     return {
       list,
       initialItems: items,
@@ -190,7 +190,7 @@ export default async function AppLayout({ children }: { children: React.ReactNod
       initialMembers: isOwner ? (membersByList[list.id] ?? []) : [],
       ownerUsername: isOwner ? null : (ownerUsernameMap[list.id] ?? null),
       allParticipants: allParticipantsByList[list.id] ?? [currentUserProfile],
-      initialVotesByItem,
+      initialVotes: votesByList[list.id] ?? [],
     };
   });
 

--- a/src/components/ListDetailClient.tsx
+++ b/src/components/ListDetailClient.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
-import { ArrowLeft, Plus, UserPlus, Pencil, LogOut } from "lucide-react";
+import { ArrowLeft, CalendarDays, Plus, UserPlus, Pencil, LogOut } from "lucide-react";
 import { useTranslations } from "next-intl";
 import Image from "next/image";
 import { createClient } from "@/lib/supabase/client";
@@ -13,6 +13,7 @@ import AddItemModal from "./AddItemModal";
 import ShareModal, { type MemberWithProfile } from "./ShareModal";
 import CreateListModal from "./CreateListModal";
 import ConfirmDeleteModal from "./ConfirmDeleteModal";
+import VoteHistoryModal, { type ListVote } from "./VoteHistoryModal";
 
 function localToday() {
   const d = new Date();
@@ -29,7 +30,7 @@ interface Props {
   initialMembers: MemberWithProfile[];
   ownerUsername?: string | null;
   allParticipants: MemberWithProfile[];
-  initialVotesByItem: Record<string, Record<string, number>>;
+  initialVotes: ListVote[];
 }
 
 export default function ListDetailClient({
@@ -42,7 +43,7 @@ export default function ListDetailClient({
   ownerUsername,
   initialMembers,
   allParticipants,
-  initialVotesByItem,
+  initialVotes,
 }: Props) {
   const [tab, setTab] = useState<"pending" | "done">("pending");
   const [items, setItems] = useState<Item[]>(initialItems);
@@ -57,10 +58,11 @@ export default function ListDetailClient({
   const [showShareModal, setShowShareModal] = useState(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [showLeaveConfirm, setShowLeaveConfirm] = useState(false);
+  const [showVoteHistory, setShowVoteHistory] = useState(false);
   const [voting, setVoting] = useState(false);
   const [timeUntilMidnight, setTimeUntilMidnight] = useState("");
   const [members, setMembers] = useState<MemberWithProfile[]>(initialMembers);
-  const [votesByItem, setVotesByItem] = useState<Record<string, Record<string, number>>>(initialVotesByItem);
+  const [votes, setVotes] = useState<ListVote[]>(initialVotes);
   const t = useTranslations("listDetail");
   const ts = useTranslations("sharing");
 
@@ -125,6 +127,16 @@ export default function ListDetailClient({
         new Date(a.completed_at ?? 0).getTime()
     );
 
+  const votesByItem = votes.reduce<Record<string, Record<string, number>>>(
+    (result, vote) => {
+      if (!result[vote.item_id]) result[vote.item_id] = {};
+      result[vote.item_id][vote.user_id] =
+        (result[vote.item_id][vote.user_id] ?? 0) + 1;
+      return result;
+    },
+    {}
+  );
+
   // Realtime subscription
   useEffect(() => {
     const channel = supabase
@@ -159,6 +171,25 @@ export default function ListDetailClient({
           }
         }
       )
+      .on(
+        "postgres_changes",
+        {
+          event: "*",
+          schema: "public",
+          table: "votes",
+          filter: `list_id=eq.${list.id}`,
+        },
+        async () => {
+          const { data } = await supabase
+            .from("votes")
+            .select("item_id, user_id, voted_date")
+            .eq("list_id", list.id);
+
+          if (!data) return;
+
+          setVotes(data);
+        }
+      )
       .subscribe();
 
     return () => {
@@ -191,25 +222,21 @@ export default function ListDetailClient({
         return i;
       })
     );
-    setVotesByItem((prev) => {
-      const next = { ...prev };
-      if (prevVotedItemId) {
-        const prevCount = next[prevVotedItemId]?.[userId] ?? 0;
-        next[prevVotedItemId] = { ...(next[prevVotedItemId] ?? {}), [userId]: Math.max(0, prevCount - 1) };
-      }
-      if (!isRevoke) {
-        const newCount = next[itemId]?.[userId] ?? 0;
-        next[itemId] = { ...(next[itemId] ?? {}), [userId]: newCount + 1 };
-      }
-      return next;
+    setVotes((previousVotes) => {
+      const withoutTodayVote = previousVotes.filter(
+        (vote) => !(vote.user_id === userId && vote.voted_date === today)
+      );
+      return isRevoke
+        ? withoutTodayVote
+        : [...withoutTodayVote, { item_id: itemId, user_id: userId, voted_date: today }];
     });
     setVotedItemId(isRevoke ? null : itemId);
 
     // Revert helper
-    const prevVotesByItem = votesByItem;
+    const previousVotes = votes;
     const revert = (restoreVotedId: string | null) => {
       setItems(prevItems);
-      setVotesByItem(prevVotesByItem);
+      setVotes(previousVotes);
       setVotedItemId(restoreVotedId);
       setVoting(false);
     };
@@ -342,6 +369,14 @@ export default function ListDetailClient({
           </button>
 
           <div className="flex items-center gap-1">
+            <button
+              onClick={() => setShowVoteHistory(true)}
+              className="w-9 h-9 rounded-full flex items-center justify-center transition-colors text-muted hover:text-text hover:bg-surface active:scale-95 active:transition-none"
+              aria-label={t("voteHistory")}
+              title={t("voteHistory")}
+            >
+              <CalendarDays size={17} />
+            </button>
             {isOwner && (
               <>
                 <button
@@ -627,6 +662,15 @@ export default function ListDetailClient({
           participants={allParticipants}
           votesByUser={votesByItem[editingItem.id] ?? {}}
           currentUserId={userId}
+        />
+      )}
+
+      {showVoteHistory && (
+        <VoteHistoryModal
+          votes={votes}
+          items={items}
+          participants={allParticipants}
+          onClose={() => setShowVoteHistory(false)}
         />
       )}
 

--- a/src/components/TabShell.tsx
+++ b/src/components/TabShell.tsx
@@ -41,7 +41,7 @@ interface ListDetail {
   initialMembers: MemberWithProfile[];
   ownerUsername: string | null;
   allParticipants: MemberWithProfile[];
-  initialVotesByItem: Record<string, Record<string, number>>;
+  initialVotes: { item_id: string; user_id: string; voted_date: string }[];
 }
 
 interface Props {

--- a/src/components/VoteHistoryModal.tsx
+++ b/src/components/VoteHistoryModal.tsx
@@ -48,58 +48,62 @@ export default function VoteHistoryModal({ votes, items, participants, onClose }
       onClick={onClose}
     >
       <div
-        className="max-h-[85vh] w-full max-w-lg overflow-y-auto rounded-t-3xl border-t border-border bg-surface-2 p-6"
+        className="flex max-h-[85vh] w-full max-w-lg flex-col overflow-hidden rounded-t-3xl border-t border-border bg-surface-2"
         style={{ paddingBottom: "max(1.5rem, env(safe-area-inset-bottom))" }}
         onClick={(event) => event.stopPropagation()}
       >
-        <div className="mx-auto mb-6 h-1 w-10 rounded-full bg-border" />
-        <div className="mb-6 flex items-center justify-between">
-          <h2 className="text-lg font-semibold text-text">{t("title")}</h2>
-          <button
-            type="button"
-            onClick={onClose}
-            className="flex h-8 w-8 items-center justify-center rounded-full border border-border bg-surface text-muted hover:text-text"
-            aria-label={t("close")}
-          >
-            <X size={16} />
-          </button>
+        <div className="shrink-0 px-6 pt-6">
+          <div className="mx-auto mb-6 h-1 w-10 rounded-full bg-border" />
+          <div className="mb-6 flex items-center justify-between">
+            <h2 className="text-lg font-semibold text-text">{t("title")}</h2>
+            <button
+              type="button"
+              onClick={onClose}
+              className="flex h-8 w-8 items-center justify-center rounded-full border border-border bg-surface text-muted hover:text-text"
+              aria-label={t("close")}
+            >
+              <X size={16} />
+            </button>
+          </div>
         </div>
 
-        {votes.length === 0 ? (
-          <p className="py-10 text-center text-sm text-muted">{t("empty")}</p>
-        ) : (
-          <div className="space-y-5">
-            {[...votesByDate.entries()].map(([date, dayVotes]) => (
-              <section key={date}>
-                <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-gold">
-                  {formatDate(date)}
-                </h3>
-                <div className="space-y-2">
-                  {dayVotes.map((vote) => {
-                    const username = participantNames.get(vote.user_id) ?? t("unknownUser");
-                    const itemName = itemNames.get(vote.item_id) ?? t("unknownItem");
-                    return (
-                      <div
-                        key={`${vote.user_id}-${vote.voted_date}`}
-                        className="flex items-start gap-3 rounded-xl border border-border bg-surface p-3"
-                      >
-                        <span
-                          className="mt-1.5 h-2 w-2 shrink-0 rounded-full"
-                          style={{ backgroundColor: userColor(vote.user_id) }}
-                        />
-                        <p className="text-sm text-muted">
-                          <span className="font-semibold text-text">{username}</span>{" "}
-                          {t("votedFor")}{" "}
-                          <span className="font-semibold text-gold">{itemName}</span>
-                        </p>
-                      </div>
-                    );
-                  })}
-                </div>
-              </section>
-            ))}
-          </div>
-        )}
+        <div className="min-h-0 flex-1 overflow-y-auto px-6">
+          {votes.length === 0 ? (
+            <p className="py-10 text-center text-sm text-muted">{t("empty")}</p>
+          ) : (
+            <div className="space-y-5">
+              {[...votesByDate.entries()].map(([date, dayVotes]) => (
+                <section key={date}>
+                  <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-gold">
+                    {formatDate(date)}
+                  </h3>
+                  <div className="space-y-2">
+                    {dayVotes.map((vote) => {
+                      const username = participantNames.get(vote.user_id) ?? t("unknownUser");
+                      const itemName = itemNames.get(vote.item_id) ?? t("unknownItem");
+                      return (
+                        <div
+                          key={`${vote.user_id}-${vote.voted_date}`}
+                          className="flex items-start gap-3 rounded-xl border border-border bg-surface p-3"
+                        >
+                          <span
+                            className="mt-1.5 h-2 w-2 shrink-0 rounded-full"
+                            style={{ backgroundColor: userColor(vote.user_id) }}
+                          />
+                          <p className="text-sm text-muted">
+                            <span className="font-semibold text-text">{username}</span>{" "}
+                            {t("votedFor")}{" "}
+                            <span className="font-semibold text-gold">{itemName}</span>
+                          </p>
+                        </div>
+                      );
+                    })}
+                  </div>
+                </section>
+              ))}
+            </div>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/src/components/VoteHistoryModal.tsx
+++ b/src/components/VoteHistoryModal.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { X } from "lucide-react";
+import { useLocale, useTranslations } from "next-intl";
+import type { Item } from "@/lib/supabase/types";
+import type { MemberWithProfile } from "./ShareModal";
+import { userColor } from "./VoteBreakdown";
+
+export interface ListVote {
+  item_id: string;
+  user_id: string;
+  voted_date: string;
+}
+
+interface Props {
+  votes: ListVote[];
+  items: Item[];
+  participants: MemberWithProfile[];
+  onClose: () => void;
+}
+
+export default function VoteHistoryModal({ votes, items, participants, onClose }: Props) {
+  const t = useTranslations("voteHistory");
+  const locale = useLocale();
+  const itemNames = new Map(items.map((item) => [item.id, item.title]));
+  const participantNames = new Map(
+    participants.map((participant) => [participant.user_id, participant.username])
+  );
+  const votesByDate = new Map<string, ListVote[]>();
+  for (const vote of [...votes].sort((a, b) => b.voted_date.localeCompare(a.voted_date))) {
+    votesByDate.set(vote.voted_date, [...(votesByDate.get(vote.voted_date) ?? []), vote]);
+  }
+
+  function formatDate(date: string) {
+    const [year, month, day] = date.split("-").map(Number);
+    return new Intl.DateTimeFormat(locale, {
+      weekday: "long",
+      day: "numeric",
+      month: "long",
+      year: "numeric",
+    }).format(new Date(year, month - 1, day));
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-[60] flex items-end justify-center"
+      style={{ backgroundColor: "rgba(0,0,0,0.7)" }}
+      onClick={onClose}
+    >
+      <div
+        className="max-h-[85vh] w-full max-w-lg overflow-y-auto rounded-t-3xl border-t border-border bg-surface-2 p-6"
+        style={{ paddingBottom: "max(1.5rem, env(safe-area-inset-bottom))" }}
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="mx-auto mb-6 h-1 w-10 rounded-full bg-border" />
+        <div className="mb-6 flex items-center justify-between">
+          <h2 className="text-lg font-semibold text-text">{t("title")}</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="flex h-8 w-8 items-center justify-center rounded-full border border-border bg-surface text-muted hover:text-text"
+            aria-label={t("close")}
+          >
+            <X size={16} />
+          </button>
+        </div>
+
+        {votes.length === 0 ? (
+          <p className="py-10 text-center text-sm text-muted">{t("empty")}</p>
+        ) : (
+          <div className="space-y-5">
+            {[...votesByDate.entries()].map(([date, dayVotes]) => (
+              <section key={date}>
+                <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-gold">
+                  {formatDate(date)}
+                </h3>
+                <div className="space-y-2">
+                  {dayVotes.map((vote) => {
+                    const username = participantNames.get(vote.user_id) ?? t("unknownUser");
+                    const itemName = itemNames.get(vote.item_id) ?? t("unknownItem");
+                    return (
+                      <div
+                        key={`${vote.user_id}-${vote.voted_date}`}
+                        className="flex items-start gap-3 rounded-xl border border-border bg-surface p-3"
+                      >
+                        <span
+                          className="mt-1.5 h-2 w-2 shrink-0 rounded-full"
+                          style={{ backgroundColor: userColor(vote.user_id) }}
+                        />
+                        <p className="text-sm text-muted">
+                          <span className="font-semibold text-text">{username}</span>{" "}
+                          {t("votedFor")}{" "}
+                          <span className="font-semibold text-gold">{itemName}</span>
+                        </p>
+                      </div>
+                    );
+                  })}
+                </div>
+              </section>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- add a calendar action to each list header
- show vote activity grouped by day, including the voter and selected item
- keep the history synchronized with optimistic voting updates and Supabase Realtime
- add localized copy for all supported languages

## Why

Vote totals showed how many votes an item had, but there was no list-level chronological view explaining who voted for what on each day.

## Impact

Users can now open the vote history directly from a list and review daily activity from newest to oldest. Existing per-item vote breakdowns remain unchanged.

## Validation

- `npm run build`
- targeted ESLint run on changed TypeScript files (no errors; existing warnings remain outside this change)